### PR TITLE
Prevent endless loop in listing 4.1

### DIFF
--- a/listings/listing_4.1.cpp
+++ b/listings/listing_4.1.cpp
@@ -30,13 +30,13 @@ std::condition_variable data_cond;
 
 void data_preparation_thread()
 {
-    while(more_data_to_prepare())
+    do
     {
         data_chunk const data=prepare_data();
         std::lock_guard<std::mutex> lk(mut);
         data_queue.push(data);
         data_cond.notify_one();
-    }
+    } while(more_data_to_prepare());
 }
 
 void data_processing_thread()


### PR DESCRIPTION
The "data_preparation_thread" is supposed to use "notify_one()"
so that ultimately the data processing thread can stop waiting.
Unfortunately, the loop condition "more_data_to_prepare" returns
false, so the "data_preparation_thread" never notifies the other
thread to exit. We can avoid the endless loop in
"data_processing_thread" by using a "do {} while()" loop in the
data preparation thread instead. This way the loop runs at least
once (as most stuff in this example) and the program exits normally.