### PR TITLE
Update listing_4.5.cpp

### DIFF
--- a/listings/listing_4.5.cpp
+++ b/listings/listing_4.5.cpp
@@ -46,7 +46,7 @@ public:
     bool try_pop(T& value)
     {
         std::lock_guard<std::mutex> lk(mut);
-        if(data_queue.empty)
+        if(data_queue.empty())
             return false;
         value=data_queue.front();
         data_queue.pop();


### PR DESCRIPTION
Fixing a typo in the source, in which you do not call the `empty()` function