### PR TITLE
`std::result_of` deprecation

### DIFF
--- a/listings/listing_4.14.cpp
+++ b/listings/listing_4.14.cpp
@@ -1,13 +1,15 @@
 #include <future>
-template<typename F,typename A>
-std::future<std::result_of<F(A&&)>::type>
-spawn_task(F&& f,A&& a)
-{
-    typedef std::result_of<F(A&&)>::type result_type;
-    std::packaged_task<result_type(A&&)>
-        task(std::move(f));
-    std::future<result_type> res(task.get_future());
-    std::thread t(std::move(task),std::move(a));
-    t.detach();
-    return res;
+
+template <typename Func, typename ...Args>
+std::future<std::invoke_result_t<Func&&, Args&&...>> spawn_task(Func &&f, Args &&...rest) {
+    typedef std::invoke_result_t<Func&&, Args&&...> result_type;
+    
+    std::packaged_task<result_type(Args&&...)> task(std::move(f));
+    
+    std::future<result_type> result(task.get_future());
+    
+    std::thread worker(std::move(task), std::move(rest)...);
+    worker.detach();
+    
+    return result;
 }


### PR DESCRIPTION
# Suggestion

See [here](https://en.cppreference.com/w/cpp/types/result_of#Notes) for reasons why `std::invoke_result_t` is to be used over `std::result_of<>::type`.

Code also amended functionally to make the template variadic (whitespace and naming amendments preferential and optional).

At the very least, lines 3 and 6 need to be amended to include `typename` in order to compile.

## Line 3
```c++
std::future<std::result_of<F(A&&)>::type>
std::future<typename std::result_of<F(A&&)>::type>
```

## Line 6
```c++
typedef std::result_of<F(A&&)>::type result_type;
typedef typename std::result_of<F(A&&)>::type result_type;
```

Tested in Xcode 14.3