### PR TITLE
Listing 4.22 - does not compile

### DIFF
--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -7,8 +7,9 @@ std::future<FinalResult> process_data(const std::vector<MyData>& vec)
     for(auto it=vec.begin(),end=vec.end();it!=end;){
         remaining_size=end-it;
         this_chunk_size=std::min(remaining_size,chunk_size);
-        results.push_back(
-            std::async(process_chunk,it,it+this_chunk_size));
+        results.push_back(std::async([=] () {
+            return process_chunk_template(it,it+this_chunk_size);
+        }));
         it+=this_chunk_size;
     }
     return std::async([all_results=std::move(results)] () mutable {

--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -3,12 +3,12 @@ std::future<FinalResult> process_data(std::vector<MyData>& vec)
 {
     size_t const chunk_size=whatever;
     std::vector<std::future<ChunkResult>> results;
-    for(auto begin=vec.begin(),end=vec.end();beg!=end;){
-        size_t const remaining_size=end-begin;
+    for(auto beg=vec.begin(),end=vec.end();beg!=end;){
+        size_t const remaining_size=end-beg;
         size_t const this_chunk_size=std::min(remaining_size,chunk_size);
         results.push_back(
-            std::async(process_chunk,begin,begin+this_chunk_size));
-        begin+=this_chunk_size;
+            std::async(process_chunk,beg,beg+this_chunk_size));
+        beg+=this_chunk_size;
     }
     return std::async([all_results=std::move(results)] () mutable {
         std::vector<ChunkResult> v;

--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -1,5 +1,5 @@
 #include <future>
-std::future<FinalResult> process_data(std::vector<MyData>& vec)
+std::future<FinalResult> process_data(const std::vector<MyData>& vec)
 {
     size_t const chunk_size=whatever;
     size_t remaining_size, this_chunk_size;

--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -3,12 +3,12 @@ std::future<FinalResult> process_data(std::vector<MyData>& vec)
 {
     size_t const chunk_size=whatever;
     std::vector<std::future<ChunkResult>> results;
-    for(auto beg=vec.begin(),end=vec.end();beg!=end;){
-        size_t const remaining_size=end-beg;
+    for(auto it=vec.begin(),end=vec.end();it!=end;){
+        size_t const remaining_size=end-it;
         size_t const this_chunk_size=std::min(remaining_size,chunk_size);
         results.push_back(
-            std::async(process_chunk,beg,beg+this_chunk_size));
-        beg+=this_chunk_size;
+            std::async(process_chunk,it,it+this_chunk_size));
+        it+=this_chunk_size;
     }
     return std::async([all_results=std::move(results)] () mutable {
         std::vector<ChunkResult> v;

--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -10,7 +10,7 @@ std::future<FinalResult> process_data(std::vector<MyData>& vec)
             std::async(process_chunk,begin,begin+this_chunk_size));
         begin+=this_chunk_size;
     }
-    return std::async([all_results=std::move(results)](){
+    return std::async([all_results=std::move(results)] () mutable {
         std::vector<ChunkResult> v;
         v.reserve(all_results.size());
         for(auto& f: all_results)

--- a/listings/listing_4.22.cpp
+++ b/listings/listing_4.22.cpp
@@ -2,10 +2,11 @@
 std::future<FinalResult> process_data(std::vector<MyData>& vec)
 {
     size_t const chunk_size=whatever;
+    size_t remaining_size, this_chunk_size;
     std::vector<std::future<ChunkResult>> results;
     for(auto it=vec.begin(),end=vec.end();it!=end;){
-        size_t const remaining_size=end-it;
-        size_t const this_chunk_size=std::min(remaining_size,chunk_size);
+        remaining_size=end-it;
+        this_chunk_size=std::min(remaining_size,chunk_size);
         results.push_back(
             std::async(process_chunk,it,it+this_chunk_size));
         it+=this_chunk_size;


### PR DESCRIPTION
Code tweaked to allow compilation.

Subjective amendments included in an attempt to make code more robust and declarative.

Please consider writing fuller-bodied code samples to provide more context to the reader, as well as ensure the code compiles and runs as intended.

Please also consider (if reasonable) more liberal use of whitespace to improve legibility at first read.

I have provided an example of my understanding of the code sample below - please feel free to amend as appropriate.

<details>
<summary><b>Listing 4.22</b> <I>(click to expand / collapse)</I></summary>

```cpp
#include <future>
#include <vector>
#include <iostream>
#include <numeric>

int process_chunk(std::vector<int>::const_iterator b, std::vector<int>::const_iterator e) {
    return std::accumulate(b, e, 0);
}

template <typename ForwardIt>
int process_chunk_template(ForwardIt b, ForwardIt e) {
    return std::accumulate(b, e, 0);
}

int gather_results(const std::vector<int> &ivec) {
    return std::accumulate(ivec.begin(), ivec.end(), 0);
}

std::future<int> process_data(const std::vector<int> &ivec) {
    const std::size_t chunk_size = ivec.size() / 4;
    std::size_t remaining_size, this_chunk_size;
    
    std::vector<std::future<int>> results;
    
    for (auto it = ivec.begin(); it != ivec.end(); /*...*/) {
        std::size_t remaining_size = std::distance(it, ivec.end());
        std::size_t this_chunk_size = std::min(remaining_size, chunk_size);
        
        // standard function
        results.push_back(std::async(process_chunk, it, it + this_chunk_size));
        
        // function templates
        
        // - explicit specialisation
        // results.push_back(std::async(process_chunk_template<std::vector<int>::const_iterator>, it, it + this_chunk_size));
        
        // - decltype shorthand
        // results.push_back(std::async(process_chunk_template<decltype(it)>, it, it + this_chunk_size));
        
        // - lambda shorthand
        // results.push_back(std::async([=] () {
        //     return process_chunk_template(it, it + this_chunk_size);
        // }));
        
        it += this_chunk_size;
    }
    
    return std::async([all_results = std::move(results)] () mutable {
        std::vector<int> v;
        v.reserve(all_results.size());
        
        for (auto &fut : all_results) { v.push_back(fut.get()); }
        
        return gather_results(v);
    });
}

int main()
{
    std::vector<int> ivec = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
    
    auto fut = process_data(ivec);
    
    std::cout << "fut.get(): " << fut.get() << '\n';
    
    return 0;
}

```
</details>

Thank you for your contributions.