### PR TITLE
Listing 4.23 will not compile

### DIFF
--- a/listings/listing_4.23.cpp
+++ b/listings/listing_4.23.cpp
@@ -3,13 +3,13 @@ std::experimental::future<FinalResult> process_data(
 {
     size_t const chunk_size=whatever;
     std::vector<std::experimental::future<ChunkResult>> results;
-    for(auto begin=vec.begin(),end=vec.end();beg!=end;){
-        size_t const remaining_size=end-begin;
+    for(auto it=vec.begin(),end=vec.end();it!=end;){
+        size_t const remaining_size=end-it;
         size_t const this_chunk_size=std::min(remaining_size,chunk_size);
         results.push_back(
             spawn_async(
-            process_chunk,begin,begin+this_chunk_size));
-        begin+=this_chunk_size;
+            process_chunk,it,it+this_chunk_size));
+        it+=this_chunk_size;
     }
     return std::experimental::when_all(
         results.begin(),results.end()).then(

--- a/listings/listing_4.23.cpp
+++ b/listings/listing_4.23.cpp
@@ -17,7 +17,7 @@ std::experimental::future<FinalResult> process_data(
              std::experimental::future<ChunkResult>>> ready_results)
         {
             std::vector<std::experimental::future<ChunkResult>>
-                all_results=ready_results .get();
+                all_results=ready_results.get();
             std::vector<ChunkResult> v;
             v.reserve(all_results.size());
             for(auto& f: all_results)


### PR DESCRIPTION
Functional change to allow compilation (please see #31 to see other potential changes).

Previous tests of `spawn_async` in place of `std::async` were not successful, but perhaps this is because `<experiemental/future>` looks to be deprecated?

For the sake of promoting and encouraging best practices, please consider more thorough testing prior to publication.