### PR TITLE
Listing 4-25 will not compile

### DIFF
--- a/listings/listing_4.25.cpp
+++ b/listings/listing_4.25.cpp
@@ -1,6 +1,6 @@
 void foo(){
     unsigned const thread_count=...;
-    latch done(thread_count);                     
+    std::latch done(thread_count);                     
     my_data data[thread_count];
     std::vector<std::future<void> > threads;
     for(unsigned i=0;i<thread_count;++i)


### PR DESCRIPTION
As it stands, this code will not compile.

Provided the headers are self-explanatory, consider exercising consistency with namespaces (like what can be seen with `std::vector<T>` and `std::future<T>`).

Either that or make namespace declarations / directives clear in the example, e.g.
```cpp
using std::experimental::latch;
// using std::latch since C++20
```
...or...
```cpp
using namespace std;
```