### PR TITLE
Listing 6.11 - Compile Error

### DIFF
--- a/listings/listing_6.11.cpp
+++ b/listings/listing_6.11.cpp
@@ -27,7 +27,7 @@ private:
                 {return item.first==key;});
         }
     public:
-        Value value_for(Key const& key,Value const& default_value) const
+        Value value_for(Key const& key,Value const& default_value)
         {
             std::shared_lock<std::shared_mutex> lock(mutex);
             bucket_iterator const found_entry=find_entry_for(key);

--- a/listings/listing_6.11.cpp
+++ b/listings/listing_6.11.cpp
@@ -20,7 +20,7 @@ private:
         bucket_data data;
         mutable std::shared_mutex mutex;
 
-        bucket_iterator find_entry_for(Key const& key) const
+        bucket_iterator find_entry_for(Key const& key)
         {
             return std::find_if(data.begin(),data.end(),
                 [&](bucket_value const& item)


### PR DESCRIPTION
Consider changing line 23 from...

https://github.com/anthonywilliams/ccia_code_samples/blob/6e7ae1d66dbd2e8f1ad18a5cf5c6d25a37b92388/listings/listing_6.11.cpp#L23
...to...
https://github.com/anthonywilliams/ccia_code_samples/blob/e893b0c531110546abf2d2677c1144ea3e290a3d/listings/listing_6.11.cpp#L23

Doesn't preserve const-ness, but fixes the following error, and allows for the code to run.

```bash
No viable conversion from returned value of type....
'std::__list_const_iterator<std::pair<int, int>, void *>'
...to function return type...
'ts::map<int, int>::bucket_type::bucket_iterator'
...(aka '__list_iterator<std::pair<int, int>, void *>')
```
---
Line 30...
https://github.com/anthonywilliams/ccia_code_samples/blob/6e7ae1d66dbd2e8f1ad18a5cf5c6d25a37b92388/listings/listing_6.11.cpp#L30
...should then also be changed to...
https://github.com/anthonywilliams/ccia_code_samples/blob/14a87fc19385f934443d92eee28067299043c5c3/listings/listing_6.11.cpp#L30
...to avoid the following compilation warning.
```bash
'this' argument to member function 'find_entry_for' has type...
`const ts::map<int, int>::bucket_type', ...
...but function is not marked const
```