### PR TITLE
Listing 6.12 - Compile Error

### DIFF
--- a/listings/listing_6.12.cpp
+++ b/listings/listing_6.12.cpp
@@ -17,7 +17,7 @@ std::map<Key,Value> threadsafe_lookup_table::get_map() const
     std::map<Key,Value> res;
     for(unsigned i=0;i<buckets.size();++i)
     {
-        for(bucket_iterator it=buckets[i].data.begin();
+        for(auto it=buckets[i].data.begin();
             it!=buckets[i].data.end();
             ++it)
         {


### PR DESCRIPTION
Consider changing...
https://github.com/anthonywilliams/ccia_code_samples/blob/6e7ae1d66dbd2e8f1ad18a5cf5c6d25a37b92388/listings/listing_6.12.cpp#L20
...to...
https://github.com/anthonywilliams/ccia_code_samples/blob/42a7c506c2d6af046154c86f10a8b7f7390b6bb9/listings/listing_6.12.cpp#L20

`typedef bucket_iterator` does not exist in the scope of our map class, but of the sub-class `bucket_type`.

We must declare `.get_map()` as a friend within `bucket_type` to allow access to its private members.
```cpp
// ...
private:
    class bucket_type {
        friend std::map<K, V> ts::map<K, V>::get_map() const;
    public:
// ...
```