### PR TITLE
Listing 7.3 - add early exit to `.pop()`

### DIFF
--- a/listings/listing_7.3.cpp
+++ b/listings/listing_7.3.cpp
@@ -23,9 +23,9 @@ public:
     }
     std::shared_ptr<T> pop()
     {
+        if (!head_) { return std::shared_ptr<T>(); }
         node* old_head=head.load();
-        while(old_head &&
-              !head.compare_exchange_weak(old_head,old_head->next));
-        return old_head ? old_head->data : std::shared_ptr<T>();
+        while(!head.compare_exchange_weak(old_head,old_head->next));
+        return old_head->data;
     }
 };

--- a/listings/listing_7.3.cpp
+++ b/listings/listing_7.3.cpp
@@ -24,8 +24,8 @@ public:
     std::shared_ptr<T> pop()
     {
         if (!head_) { return std::shared_ptr<T>(); }
-        node* old_head=head.load();
-        while(!head.compare_exchange_weak(old_head,old_head->next));
-        return old_head->data;
+        node* original_head=head.load();
+        while(!head.compare_exchange_weak(original_head,original_head->next));
+        return original_head->data;
     }
 };


### PR DESCRIPTION
It seems odd to perform work on a node that could potentially be a `nullptr` from the moment the function is called.

I hope I'm correct in saying that `.compare_exchange_weak(...)` will return `true` if `head` still refers to our original `old_head` (i.e. no other thread has had a chance to modify it), but if that `old_head` was `nullptr` to begin with, then would `old_head->next` not throw after a successful CAS check?

https://github.com/anthonywilliams/ccia_code_samples/blob/6134deed3865de373f438e2a34fea53bba2c93ba/listings/listing_7.3.cpp#L24-L30

---
The same thing applies to `void pop(T &val)` a few pages prior - an early exit allows the code the run without throwing for bad access to `old_head->next`.

---
Arguably, maybe changing `old_head` to `original_head` would be more conducive to helping readers grasp the concept of `.compare_exchange_weak(...)`.