### PR TITLE
Listing 7.12 - Undefined behaviour

### DIFF
--- a/listings/listing_7.12.cpp
+++ b/listings/listing_7.12.cpp
@@ -31,7 +31,7 @@ public:
         {
             increase_head_count(old_head);
             node* const ptr=old_head.ptr;
-            if(!ptr)
+            if(!ptr->next.ptr)
             {
                 return std::shared_ptr<T>();
             }


### PR DESCRIPTION
Please consider modifying the implicit-boolean `ptr` check at line 34 to `ptr->next.ptr`.

---
https://github.com/anthonywilliams/ccia_code_samples/blob/6e7ae1d66dbd2e8f1ad18a5cf5c6d25a37b92388/listings/listing_7.12.cpp#L34
https://github.com/anthonywilliams/ccia_code_samples/blob/16d50777974df5e8d5c94ba23f914726f06fe36e/listings/listing_7.12.cpp#L34

---
Even if the stack is empty while calling the destructor, `ptr` is a valid pointer from the moment we call `head.load()` - this leads to undefined behaviour inside one of the atomic fetch operations.

---
![image](https://github.com/anthonywilliams/ccia_code_samples/assets/34002836/880a3ee6-7a5a-4841-93c0-7da73af1f3a0)
---
![image](https://github.com/anthonywilliams/ccia_code_samples/assets/34002836/aae9c346-51be-43c8-8ac4-fd8b3e2a0072)
---
![image](https://github.com/anthonywilliams/ccia_code_samples/assets/34002836/bf929609-7b2c-4c48-ad88-418827a07084)
---
![image](https://github.com/anthonywilliams/ccia_code_samples/assets/34002836/37a24d32-28f4-4dc1-86bc-d4a14a73092b)

---
Whilst this has been a useful exercise in debugging, please also consider uploading fully-functioning code as a means of verifying that the code published actually functions as intended.

I have attached an example here for anyone coming up against similar issues.