### PR TITLE
Listing 7.18 / 7.19 / 7.20 - Potential Data Race

### DIFF
--- a/listings/listing_7.18.cpp
+++ b/listings/listing_7.18.cpp
@@ -36,7 +36,7 @@ private:    struct node;
             }
             while(!count.compare_exchange_strong(
                       old_counter,new_counter,
-                      std::memory_order_acquire,std::memory_order_relaxed));
+                      std::memory_order_acq_rel,std::memory_order_relaxed));
             if(!new_counter.internal_count &&
                !new_counter.external_counters)
             {


### PR DESCRIPTION
Given the following reading material [here](https://stackoverflow.com/questions/55704567/how-to-understand-calling-compare-exchange-strong-with-stdmemory-order-acquire) and [here](https://stackoverflow.com/questions/74127715/why-are-these-memory-orders-applied-here-in-the-implementation-of-the-lock-free), please consider upgrading the memory-ordering of our `.compare_exchange_strong()` operations from...
```cpp
std::memory_order_acquire
```
...to...
```cpp
std::memory_order_acq_rel
```
...to ensure all accesses to `ptr` happen before its deletion.

---
Attached are examples of [before](https://godbolt.org/z/1n4f4ceTz) and [after](https://godbolt.org/z/73TMd8Pnz) results from Godbolt using thread sanitiser.

---
Thank you to [Nate Eldridge](https://stackoverflow.com/users/634919/nate-eldredge) for the great explanation and testing.