### PR TITLE
Listing 8.1 - Compile and runtime fixes

### DIFF
--- a/listings/listing_8.1.cpp
+++ b/listings/listing_8.1.cpp
@@ -32,7 +32,7 @@ struct sorter
 
     void try_sort_chunk()
     {
-        boost::shared_ptr<chunk_to_sort > chunk=chunks.pop();
+        std::shared_ptr<chunk_to_sort > chunk=chunks.pop();
         if(chunk)
         {
             sort_chunk(chunk);
@@ -79,7 +79,7 @@ struct sorter
         return result;
     }
 
-    void sort_chunk(boost::shared_ptr<chunk_to_sort > const& chunk)
+    void sort_chunk(std::shared_ptr<chunk_to_sort > const& chunk)
     {
         chunk->promise.set_value(do_sort(chunk->data));
     }

--- a/listings/listing_8.1.cpp
+++ b/listings/listing_8.1.cpp
@@ -11,7 +11,7 @@ struct sorter
         std::promise<std::list<T> > promise;
     };
 
-    thread_safe_stack<chunk_to_sort> chunks;
+    threadsafe_stack<chunk_to_sort> chunks;
     std::vector<std::thread> threads;
     unsigned const max_thread_count;
     std::atomic<bool> end_of_data;


### PR DESCRIPTION
PR in response to issue #39.

---
In order for this code to run, we must perform the following commits and amend listing 6.1 to return an empty shared pointer at line 37 instead of throwing.
```cpp
// if(data.empty()) throw empty_stack();
if(data.empty()) return std::shared_ptr<T>();
```

---
Tested with a simple list of ints, but will investigate with larger containers of varying types to benchmark speed comparisons.
<details>
<summary><b>Test case</b> - <I>(click to expand / collapse)</I></summary>

</br>

```cpp
template <typename T>
void print_list(const std::list<T> &il) {
    for (auto &&e : il) {
        std::cout << e << ' ';
    } std::cout << '\n';
}

int main()
{
    std::list<int> il = { 1, 4, 5, 3, 6, 7, 4 };
    print_list(il);
    
    auto sorted_il = parallel_quick_sort(il);
    print_list(sorted_il);
    
    return 0;
}

// 1 4 5 3 6 7 4 
// 1 3 4 4 5 6 7 
// Program ended with exit code: 0
```
</details>

---
I'm attempting to try implement the same sorter with our lock-free stack, but issues exist in all of the implementations provided in chapter 7, and `boost` is showing data races with Thread Sanitiser, so I'll come back to this when I know where to start.

---
A relatively simple fix, but it would just be nice if it worked out of the box instead of having to correct it.