### PR TITLE
Listing 8.2 - Compiler error (missing headers)

### DIFF
--- a/listings/listing_8.2.cpp
+++ b/listings/listing_8.2.cpp
@@ -1,6 +1,8 @@
 #include <vector>
 #include <thread>
 #include <algorithm>
+#include <numeric>
+#include <functional>
 template<typename Iterator,typename T>
 struct accumulate_block
 {


### PR DESCRIPTION
Not sure what compiler this code was tested on, but we need the following headers to allow our example to compile.
```cpp
#include <numeric>    // std::accumulate
#include <functional> // std::mem_fn
```
### Godbolt
Before: [gcc](https://godbolt.org/z/7Tn3847nW) | [clang](https://godbolt.org/z/fE8v8d36f)
After: [gcc](https://godbolt.org/z/3nK79zh8K) | [clang](https://godbolt.org/z/5T3vh17nd)