### PR TITLE
Listing 8.3 - Compiler Error

### DIFF
--- a/listings/listing_8.3.cpp
+++ b/listings/listing_8.3.cpp
@@ -2,6 +2,8 @@
 #include <thread>
 #include <vector>
 #include <future>
+#include <numeric>
+#include <functional>
 template<typename Iterator,typename T>
 struct accumulate_block
 {

--- a/listings/listing_8.3.cpp
+++ b/listings/listing_8.3.cpp
@@ -42,7 +42,7 @@ T parallel_accumulate(Iterator first,Iterator last,T init)
         Iterator block_end=block_start;
         std::advance(block_end,block_size);
         std::packaged_task<T(Iterator,Iterator)> task(
-            accumulate_block<Iterator,T>());
+            (accumulate_block<Iterator,T>()));
         futures[i]=task.get_future();
         threads[i]=std::thread(std::move(task),block_start,block_end);
         block_start=block_end;

--- a/listings/listing_8.3.cpp
+++ b/listings/listing_8.3.cpp
@@ -47,7 +47,7 @@ T parallel_accumulate(Iterator first,Iterator last,T init)
         threads[i]=std::thread(std::move(task),block_start,block_end);
         block_start=block_end;
     }
-    T last_result=accumulate_block<Iterator,T>(block_start,last);
+    T last_result=accumulate_block<Iterator,T>()(block_start,last);
 
     std::for_each(threads.begin(),threads.end(),
                   std::mem_fn(&std::thread::join));


### PR DESCRIPTION
### Issues
1)  Two headers are missing (`<numeric>` and `<functional>`)
2) Our `std::packaged_task` is constructed incorrectly (requires extra parentheses)
3) The default constructor for `accumulate_block` is mistakenly called in place of `accumulate_block<Iterator,T>::operator()`

---
Stylistically it might also be nice to replace lines 50-51...
https://github.com/anthonywilliams/ccia_code_samples/blob/6e7ae1d66dbd2e8f1ad18a5cf5c6d25a37b92388/listings/listing_8.3.cpp#L50-L51
... with a range-based for loop.
```cpp
for (auto &t : threads) { t.join(); }
```
---
Tested successfully on gcc, clang and apple clang.