### PR TITLE
Listing 8.11 - Compile Error

### DIFF
--- a/listings/listing_8.11.cpp
+++ b/listings/listing_8.11.cpp
@@ -57,7 +57,7 @@ void parallel_partial_sum(Iterator first,Iterator last)
     unsigned long const length=std::distance(first,last);
 
     if(!length)
-        return last;
+        return;
 
     unsigned long const min_per_thread=25;
     unsigned long const max_threads=

--- a/listings/listing_8.11.cpp
+++ b/listings/listing_8.11.cpp
@@ -1,10 +1,20 @@
 #include <future>
 #include <algorithm>
 #include <vector>
-struct join_threads
-{
-    join_threads(std::vector<std::thread>&)
-    {}
+
+class join_threads {
+public:
+    join_threads(std::vector<std::thread> &threads) : threads_(threads) { }
+
+    ~join_threads()
+    {
+        for (auto &t : threads_) {
+            if (t.joinable()) { t.join(); }
+        }
+    }
+
+private:
+    std::vector<std::thread> &threads_;
 };
 
 template<typename Iterator>

--- a/listings/listing_8.11.cpp
+++ b/listings/listing_8.11.cpp
@@ -24,7 +24,7 @@ void parallel_partial_sum(Iterator first,Iterator last)
                 std::partial_sum(begin,end,begin);
                 if(previous_end_value)
                 {
-                    value_type& addend=previous_end_value->get();
+                    value_type const& addend=previous_end_value->get();
                     *last+=addend;
                     if(end_value)
                     {


### PR DESCRIPTION
Two changes are needed to get this code to compile:

1) Change line 60 from `return last` to return (this is a `void` function, we our not returning an `_OutputIterator`
2) Make `addend` a constant reference at line 27

---
One further change required to stop the code from crashing at runtime.

1) Complete the `join_threads`class