### PR TITLE
Listing 8.13 - Incorrect Implementation

### DIFF
--- a/listings/listing_8.13.cpp
+++ b/listings/listing_8.13.cpp
@@ -81,6 +81,10 @@ void parallel_partial_sum(Iterator first,Iterator last)
             {
                 ith_element=buffer[i];
             }
+            else
+            {
+                buffer[i] = ith_element;
+            }
             b.done_waiting();
         }
     };

--- a/listings/listing_8.13.cpp
+++ b/listings/listing_8.13.cpp
@@ -2,10 +2,17 @@
 #include <thread>
 #include <vector>
 
-struct join_threads
-{
-    join_threads(std::vector<std::thread>&)
-    {}
+class join_threads {
+public:
+    explicit join_threads(std::vector<std::thread> &threads) : threads_(threads) { }
+    
+    ~join_threads()
+    {
+        for (auto &t : threads_)
+            if (t.joinable()) { t.join(); }
+    }
+private:
+    std::vector<std::thread> &threads_;
 };
     
 

--- a/listings/listing_8.13.cpp
+++ b/listings/listing_8.13.cpp
@@ -99,7 +99,6 @@ void parallel_partial_sum(Iterator first,Iterator last)
     std::vector<std::thread> threads(length-1);
     join_threads joiner(threads);
 
-    Iterator block_start=first;
     for(unsigned long i=0;i<(length-1);++i)
     {
         threads[i]=std::thread(process_element(),first,last,


### PR DESCRIPTION
Most of this has been addressed in an earlier issue, so thank you to @dragon-dreamer and @xxrlzzz.

* #5 

As it stands, an incomplete `join_threads` will result in a runtime error, and functionally we need to ensure an `else` statement is included should `update_source` not return `true`.

Our `block_start` iterator is also unused, so maybe this was a throwback to earlier examples where `block_start` and `block_end` were passed recursively?

Good catch, guys / dolls.
