### PR TITLE
Listing 9.2 - Deprecations

### DIFF
--- a/listings/listing_9.2.cpp
+++ b/listings/listing_9.2.cpp
@@ -48,10 +48,10 @@ public:
     std::deque<function_wrapper> work_queue;
 
     template<typename FunctionType>
-    std::future<typename std::result_of<FunctionType()>::type>
+    std::future<std::invoke_result_t<FunctionType&&>>
     submit(FunctionType f)
     {
-        typedef typename std::result_of<FunctionType()>::type result_type;
+        typedef std::invoke_result_t<FunctionType&&> result_type;
         
         std::packaged_task<result_type()> task(std::move(f));
         std::future<result_type> res(task.get_future());

--- a/listings/listing_9.2.cpp
+++ b/listings/listing_9.2.cpp
@@ -22,7 +22,7 @@ class function_wrapper
 public:
     template<typename F>
     function_wrapper(F&& f):
-        impl(new impl_type<F>(std::move(f)))
+        impl(std::make_unique<impl_type<F>>(std::move(f)))
     {}
 
     void call() { impl->call(); }

--- a/listings/listing_9.2.cpp
+++ b/listings/listing_9.2.cpp
@@ -21,17 +21,17 @@ class function_wrapper
     };
 public:
     template<typename F>
-    function_wrapper(F&& f):
+    function_wrapper(F&& f) noexcept:
         impl(std::make_unique<impl_type<F>>(std::move(f)))
     {}
 
     void call() { impl->call(); }
 
-    function_wrapper(function_wrapper&& other):
+    function_wrapper(function_wrapper&& other) noexcept:
         impl(std::move(other.impl))
     {}
 
-    function_wrapper& operator=(function_wrapper&& other)
+    function_wrapper& operator=(function_wrapper&& other) noexcept
     {
         impl=std::move(other.impl);
         return *this;


### PR DESCRIPTION
Slight tweaks to address deprecations, unnecessary calls to `operator new` and use of `noexcept` with move(-assignment) operations.

There also appears to be a data race when using one of the multithreaded queue implementations from Chapter 6, although this could be as a result of my changes, so I'm open to feedback while I go back to verify with the original implementation.

<details>
<summary><b>Possible results</b> - <I>(click to expand / collapse)</I></summary>

</br>

```cpp
void go_forth_and_multiply(std::vector<int> &ivec) {
    thread_pool tp;
    for (int &i : ivec) { tp.submit([&] () { i *= i; }); }
}
```

```bash
ivec: 1 2 3 4 5 6 7 8 9 10 
ivec: 1 4 9 16 25 36 49 64 81 100 

ivec: 1 2 3 4 5 6 7 8 9 10 
ivec: 1 4 9 16 25 36 49 8 9 10 

ivec: 1 2 3 4 5 6 7 8 9 10 
ivec: 1 4 9 16 25 6 7 8 9 10 

ivec: 1 2 3 4 5 6 7 8 9 10 
ivec: 1 2 3 4 5 6 7 8 9 10 
```
</details>

---
```cpp
for (int i = 0; i != ivec.size(); ++i) {
    tp.submit([&, i] () { ivec[i] *= ivec[i]; });
}
```
...produces similar results.