### PR TITLE
Listing 9.2 - Remove duplicate header

### DIFF
--- a/listings/listing_9.2.cpp
+++ b/listings/listing_9.2.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <functional>
 #include <iostream>
-#include <iostream>
 
 class function_wrapper
 {


### PR DESCRIPTION
`<iostream>` appears to be declared twice here - just needs removed.