### PR TITLE
Listing 9.3 - Compile Error

### DIFF
--- a/listings/listing_9.3.cpp
+++ b/listings/listing_9.3.cpp
@@ -2,6 +2,14 @@
 #include <future>
 #include <thread>
 
+template <typename _ForwardIt, typename _Tp>
+struct accumulate_block {
+    _Tp operator() (_ForwardIt __first, _ForwardIt __last)
+    {
+        return std::accumulate(__first, __last, __Tp{});
+    }
+};
+
 template<typename Iterator,typename T>
 T parallel_accumulate(Iterator first,Iterator last,T init)
 {

--- a/listings/listing_9.3.cpp
+++ b/listings/listing_9.3.cpp
@@ -30,7 +30,7 @@ T parallel_accumulate(Iterator first,Iterator last,T init)
         Iterator block_end=block_start;
         std::advance(block_end,block_size);
         futures[i]=pool.submit([=] {
-            accumulate_block<Iterator,T>()(block_start,block_end);
+            return accumulate_block<Iterator,T>()(block_start,block_end);
         });
         block_start=block_end;
     }

--- a/listings/listing_9.3.cpp
+++ b/listings/listing_9.3.cpp
@@ -29,7 +29,7 @@ T parallel_accumulate(Iterator first,Iterator last,T init)
     {
         Iterator block_end=block_start;
         std::advance(block_end,block_size);
-        futures[i]=pool.submit(accumulate_block<Iterator,T>());
+        futures[i]=pool.submit(accumulate_block<Iterator,T>()(block_start,block_end));
         block_start=block_end;
     }
     T last_result=accumulate_block()(block_start,last);

--- a/listings/listing_9.3.cpp
+++ b/listings/listing_9.3.cpp
@@ -29,7 +29,9 @@ T parallel_accumulate(Iterator first,Iterator last,T init)
     {
         Iterator block_end=block_start;
         std::advance(block_end,block_size);
-        futures[i]=pool.submit(accumulate_block<Iterator,T>()(block_start,block_end));
+        futures[i]=pool.submit([=] {
+            accumulate_block<Iterator,T>()(block_start,block_end);
+        });
         block_start=block_end;
     }
     T last_result=accumulate_block()(block_start,last);


### PR DESCRIPTION
A `return` is needed when calling the two-parameter version of `accumulate_block()` inside of the lambda function.

```diff
futures[i] = pool.submit([=] () {
-    accumulate_block<_ForwardIt, _Tp>()(block_start, block_end);
+    return accumulate_block<_ForwardIt, _Tp>()(block_start, block_end);
});
```

Without it, we receive the following error:
```bash
No viable overloaded '='
```
The listing in this repo ([here](https://github.com/anthonywilliams/ccia_code_samples/blob/main/listings/listing_9.3.cpp)) also doesn't mirror what was written in the book, so I've first brought them in sync before applying the correction.