### PR TITLE
fix: listing_2.6 sub thread is not running

### DIFF
--- a/listings/listing_2.6.cpp
+++ b/listings/listing_2.6.cpp
@@ -22,6 +22,8 @@ public:
 void do_something(int& i)
 {
     ++i;
+    if (i % 100000 == 0)
+        printf("%d\n", i);
 }
 
 struct func
@@ -45,7 +47,8 @@ void do_something_in_current_thread()
 void f()
 {
     int some_local_state;
-    scoped_thread t(std::thread(func(some_local_state)));
+    // scoped_thread t(std::thread(func(some_local_state)));
+    scoped_thread t(std::move(std::thread(func(some_local_state))));
         
     do_something_in_current_thread();
 }


### PR DESCRIPTION
Hello!
I've been studying CCIA recently and found a problem in Listing 2.6: the sub-thread is not running when executing the example on my computer.

However, it works when I revise line 48:
scoped_thread t(std::move(std::thread(func(some_local_state))));
