### PR TITLE
Listing_7.21 - Missing release_ref before return

### DIFF
--- a/listings/listing_7.21.cpp
+++ b/listings/listing_7.21.cpp
@@ -19,6 +19,7 @@ public:
             node* const ptr=old_head.ptr;
             if(ptr==tail.load().ptr)
             {
+                ptr->release_ref();
                 return std::unique_ptr<T>();
             }
             counted_node_ptr next=ptr->next.load();


### PR DESCRIPTION
You have to release since you have already incremented the external count.